### PR TITLE
Added irc_port specification. User can now change the port easily.

### DIFF
--- a/lib/zabbirc/configuration.rb
+++ b/lib/zabbirc/configuration.rb
@@ -21,6 +21,8 @@ module Zabbirc
 
     config_accessor :irc_server
     config_accessor :irc_port
+    config_accessor :irc_ssl
+    config_accessor :irc_ssl_verify
     config_accessor :irc_channels
 
     config_accessor :events_check_interval
@@ -58,6 +60,8 @@ module Zabbirc
 
     config.irc_server = "irc.freenode.org"
     config.irc_port = 6667
+    config.irc_ssl = false
+    config.irc_ssl_verify = false
     config.irc_channels = ["#zabbirc-test", "#zabbirc-test-2"]
     config.colors = true
   end

--- a/lib/zabbirc/configuration.rb
+++ b/lib/zabbirc/configuration.rb
@@ -20,6 +20,7 @@ module Zabbirc
     config_accessor :zabbix_password
 
     config_accessor :irc_server
+    config_accessor :irc_port
     config_accessor :irc_channels
 
     config_accessor :events_check_interval
@@ -56,6 +57,7 @@ module Zabbirc
     config.default_events_priority = :high
 
     config.irc_server = "irc.freenode.org"
+    config.irc_port = 6667
     config.irc_channels = ["#zabbirc-test", "#zabbirc-test-2"]
     config.colors = true
   end

--- a/lib/zabbirc/service.rb
+++ b/lib/zabbirc/service.rb
@@ -22,6 +22,7 @@ module Zabbirc
       @cinch_bot = Cinch::Bot.new do
         configure do |c|
           c.server = Zabbirc.config.irc_server
+	  c.port = Zabbirc.config.irc_port
           c.channels = Zabbirc.config.irc_channels
           c.nick = "zabbirc"
           c.plugins.plugins = [Irc::Plugin]

--- a/lib/zabbirc/service.rb
+++ b/lib/zabbirc/service.rb
@@ -25,6 +25,8 @@ module Zabbirc
 	  c.port = Zabbirc.config.irc_port
           c.channels = Zabbirc.config.irc_channels
           c.nick = "zabbirc"
+	  c.ssl.use = Zabbirc.config.irc_ssl
+	  c.ssl.verify = Zabbirc.config.irc_ssl_verify
           c.plugins.plugins = [Irc::Plugin]
         end
       end

--- a/templates/zabbirc_config.rb
+++ b/templates/zabbirc_config.rb
@@ -7,6 +7,7 @@ Zabbirc.configure do |config|
   ### IRC configurations
   # config.irc_server = "irc.freenode.org"
   # config.irc_channels = ["#zabbirc-test", "#zabbirc-test-2"]
+  # config.irc_port = 6667
 
   ### Zabbirc configurations
   # config.events_check_interval = 10.seconds

--- a/templates/zabbirc_config.rb
+++ b/templates/zabbirc_config.rb
@@ -8,6 +8,8 @@ Zabbirc.configure do |config|
   # config.irc_server = "irc.freenode.org"
   # config.irc_channels = ["#zabbirc-test", "#zabbirc-test-2"]
   # config.irc_port = 6667
+  # config.irc_ssl = false
+  # config.irc_ssl_verify = false
 
   ### Zabbirc configurations
   # config.events_check_interval = 10.seconds


### PR DESCRIPTION
Allow user to specify the irc port. Idea came about because the net I'm using does not have 6667 at all, and that's the default in Cinch, but it's configurable.