### PR TITLE
allow dots in the hostnames

### DIFF
--- a/lib/zabbirc/irc/base_command.rb
+++ b/lib/zabbirc/irc/base_command.rb
@@ -21,8 +21,8 @@ module Zabbirc
       end
 
       def parse_arguments cmd
-        cmd.scan(/'[a-zA-Z0-9_\-,# ]+'|[a-zA-Z0-9_\-,#]+/).collect do |x|
-          x.match(/[a-zA-Z0-9_\-,# ]+/)[0]
+        cmd.scan(/'[a-zA-Z0-9_\-\.,# ]+'|[a-zA-Z0-9_\-\.,#]+/).collect do |x|
+          x.match(/[a-zA-Z0-9_\-\.,# ]+/)[0]
         end
       end
 


### PR DESCRIPTION
Without this, the arguments array is populated incorrectly.
For example:

`!host server.xyz.com`

would execute `Zabbix::Host.get('search' => { name: 'server' })` which would
obviously return incorrect number of results, because it would match both
`server.xyz.com` and `server.abc.com.`
